### PR TITLE
dialog() must be NONBANKED because it receives the pointer to somethi…

### DIFF
--- a/include/dialog.h
+++ b/include/dialog.h
@@ -5,6 +5,6 @@
 
 void appearDialog() BANKED;
 void disappearDialog() BANKED;
-uint8_t dialog(uint8_t *message, uint8_t handleOverlays) BANKED;
+uint8_t dialog(uint8_t *message, uint8_t handleOverlays) NONBANKED;
 
 #endif

--- a/src/dialog.c
+++ b/src/dialog.c
@@ -38,7 +38,7 @@ void disappearDialog() BANKED {
   move_win(7, 146);
 }
 
-uint8_t dialog(uint8_t *message, uint8_t handleOverlays) BANKED {
+uint8_t dialog(uint8_t *message, uint8_t handleOverlays) NONBANKED {
   if (handleOverlays) {
     hideLowerOverlay();
   }


### PR DESCRIPTION
…ng in a bank (bank is switched because we are calling from the BANKED function)